### PR TITLE
feat(stats): add memory and concurrency stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2682,9 +2682,9 @@
       }
     },
     "epsagon": {
-      "version": "1.81.4",
-      "resolved": "https://registry.npmjs.org/epsagon/-/epsagon-1.81.4.tgz",
-      "integrity": "sha512-GdRRfyumPKoKI4S/sDijg5rF2StwbJIWDz77lPlRSmmlaaRVlVCnc+6REBe3zcV2rkTWX62Hz17tDUj/RprXfQ==",
+      "version": "1.81.5",
+      "resolved": "https://registry.npmjs.org/epsagon/-/epsagon-1.81.5.tgz",
+      "integrity": "sha512-D+RVCBVbQ0MObZ4PyEJVLMFRcFbk0ThESRUtUf/GqyChbovpRWieMqByFcdkTdoHpEEG+mICpaWmJNR41OI7HA==",
       "requires": {
         "axios": "^0.19.0",
         "google-protobuf": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/adobe/helix-epsagon#readme",
   "dependencies": {
-    "epsagon": "1.81.4"
+    "epsagon": "1.81.5"
   },
   "devDependencies": {
     "@adobe/eslint-config-helix": "1.1.3",

--- a/src/action-status.js
+++ b/src/action-status.js
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const fs = require('fs');
+const crypto = require('crypto');
+const { tracer, eventInterface } = require('epsagon');
+
+let numInvocations = 0;
+const startTime = Date.now();
+const uuid = crypto.randomBytes(16).toString('hex');
+const runningActivations = new Set();
+
+/**
+ * Returns the number of open file handles. currently not needed anymore but can be enabled if
+ * desired.
+ * @param {Logger} log the logger.
+ * @returns {Promise<number>} The number of open file handles.
+ */
+/* istanbul ignore next */
+// eslint-disable-next-line no-unused-vars
+async function getNumOpenFileHandles(log) {
+  return new Promise((resolve) => {
+    fs.readdir('/proc/self/fd', (err, list) => {
+      if (err) {
+        log.info(`unable to read /proc/self/fd: ${err.message}`);
+        resolve(-1);
+      } else {
+        resolve(list.length);
+      }
+    });
+  });
+}
+
+/**
+ * Add a metadata to the runner of the current trace.
+ */
+function addToMetadata(log, map) {
+  try {
+    const tracerObj = tracer.getTrace();
+    if (!tracerObj || !tracerObj.currRunner) {
+      log.debug('Failed to data without an active tracer');
+      return;
+    }
+    eventInterface.addToMetadata(tracerObj.currRunner, map);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Wraps the given `action` with functionality to log additional memory and concurrency information.
+ * If epsagon is enabled, it will also add the respective metadata to the current epsagon tracer.
+ *
+ * @param {ActionFunction} action
+ *        Original OpenWhisk action main function
+ * @returns {ActionFunction} a new function with the same signature as your original main function
+ */
+function traceActionStatus(action) {
+  return async (params) => {
+    const { __ow_logger: log = console } = params;
+
+    // if logger doesn't have the `infoFields` method, create polyfill
+    if (!log.infoFields) {
+      log.infoFields = (msg, obj) => {
+        log.info(`${msg} ${JSON.stringify(obj)}`);
+      };
+    }
+
+    const memBegin = process.memoryUsage().rss;
+    const age = Date.now() - startTime;
+    numInvocations += 1;
+    // eslint-disable-next-line no-underscore-dangle
+    const activationId = process.env.__OW_ACTIVATION_ID;
+    runningActivations.add(activationId);
+    log.infoFields('action-status-begin', {
+      status: {
+        mem_beg: memBegin,
+      },
+      container: {
+        age,
+        uuid,
+        numInvocations,
+        concurrency: runningActivations.size,
+      },
+    });
+    try {
+      addToMetadata(log, {
+        mem_beg: memBegin,
+        container: {
+          age,
+          uuid,
+          numInvocations,
+          concurrency: runningActivations.size,
+        },
+      });
+      return await action(params);
+    } finally {
+      const memEnd = process.memoryUsage().rss;
+      const memDelta = memEnd - memBegin;
+      log.infoFields('action-status-end', {
+        status: {
+          mem_beg: memBegin,
+          mem_end: memEnd,
+          mem_delta: memDelta,
+        },
+      });
+      addToMetadata(log, {
+        mem_end: memEnd,
+        mem_delta: memDelta,
+      });
+      runningActivations.delete(activationId);
+    }
+  };
+}
+
+module.exports = traceActionStatus;

--- a/src/action-status.js
+++ b/src/action-status.js
@@ -46,7 +46,7 @@ function addToMetadata(log, map) {
   try {
     const tracerObj = tracer.getTrace();
     if (!tracerObj || !tracerObj.currRunner) {
-      log.debug('Failed to data without an active tracer');
+      log.debug('Failed to log data without an active tracer');
       return;
     }
     eventInterface.addToMetadata(tracerObj.currRunner, map);

--- a/src/epsagon.js
+++ b/src/epsagon.js
@@ -72,7 +72,13 @@ function epsagon(action, opts = {}) {
       // eslint-disable-next-line global-require
       const { openWhiskWrapper } = require('epsagon');
       log.info('instrumenting epsagon.');
-      ret = openWhiskWrapper(action, options)(params);
+
+      // same as above - only require if really needed
+      // eslint-disable-next-line global-require
+      const traceActionStatus = require('./action-status.js');
+      const tracedAction = traceActionStatus(action);
+
+      ret = openWhiskWrapper(tracedAction, options)(params);
     } else {
       ret = action(params);
     }

--- a/test/action-status.test.js
+++ b/test/action-status.test.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-underscore-dangle */
+const assert = require('assert');
+const crypto = require('crypto');
+const proxyquire = require('proxyquire').noPreserveCache();
+const sinon = require('sinon');
+const { wrap } = require('@adobe/openwhisk-action-utils');
+
+const DEFAULT_PARAMS = {
+  testParams: 'foo',
+};
+
+const simpleAction = () => 'ok';
+
+const wrapperStub = sinon.stub().callsFake((action) => (params) => action(params));
+
+const eventStub = sinon.stub();
+
+let currentRunner = null;
+
+const epsagon = proxyquire('../src/epsagon.js', {
+  epsagon: {
+    openWhiskWrapper: wrapperStub,
+  },
+  './action-status.js': proxyquire('../src/action-status.js', {
+    epsagon: {
+      tracer: {
+        getTrace() {
+          return {
+            currRunner: currentRunner,
+          };
+        },
+      },
+      eventInterface: {
+        addToMetadata: eventStub,
+      },
+    },
+  }),
+});
+
+describe('Action Status Tests', () => {
+  let activationId;
+  beforeEach(() => {
+    wrapperStub.resetHistory();
+    eventStub.resetHistory();
+    activationId = crypto.randomBytes(16).toString('hex');
+    Object.assign(process.env, {
+      __OW_ACTION_NAME: '/helix/helix-epsagon@1.0.2',
+      __OW_ACTION_VERSION: '0.0.3',
+      __OW_ACTIVATION_ID: activationId,
+      __OW_API_HOST: 'https://runtime.adobe.io',
+      __OW_NAMESPACE: 'helix-testing',
+    });
+  });
+  afterEach(() => {
+    delete process.env.__OW_ACTION_NAME;
+    delete process.env.__OW_ACTION_VERSION;
+    delete process.env.__OW_ACTIVATION_ID;
+    delete process.env.__OW_API_HOST;
+    delete process.env.__OW_NAMESPACE;
+  });
+
+  it('action status reports stats', async () => {
+    currentRunner = {};
+    const result = await wrap(simpleAction).with(epsagon)({
+      ...DEFAULT_PARAMS,
+      EPSAGON_TOKEN: '1234',
+    });
+    assert.equal(result, 'ok');
+
+    const args1 = eventStub.getCall(0).args[1];
+    assert.ok(args1.mem_beg);
+    assert.ok(args1.container.uuid);
+    assert.ok(args1.container.age);
+    assert.equal(args1.container.concurrency, 1);
+    assert.equal(args1.container.numInvocations, 1);
+
+    const args2 = eventStub.getCall(1).args[1];
+    assert.ok(args2.mem_end);
+    assert.equal(args2.mem_delta, args2.mem_end - args1.mem_beg);
+
+    // run again
+    const result2 = await wrap(simpleAction).with(epsagon)({
+      ...DEFAULT_PARAMS,
+      EPSAGON_TOKEN: '1234',
+    });
+    assert.equal(result2, 'ok');
+    const args3 = eventStub.getCall(2).args[1];
+    assert.ok(args3.mem_beg);
+    assert.equal(args3.container.uuid, args1.container.uuid);
+    assert.ok(args3.container.age);
+    assert.equal(args3.container.concurrency, 1);
+    assert.equal(args3.container.numInvocations, 2);
+  });
+
+  it('action status does not report stat with no espagon', async () => {
+    currentRunner = null;
+    const result = await wrap(simpleAction).with(epsagon)({
+      ...DEFAULT_PARAMS,
+      EPSAGON_TOKEN: '1234',
+    });
+    assert.equal(result, 'ok');
+
+    assert.equal(eventStub.getCalls().length, 0);
+  });
+});

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -51,6 +51,10 @@ async function run(params) {
 }
 
 describe('Helix Fetch', () => {
+  after(async () => {
+    await fetchAPI.disconnectAll();
+  });
+
   it('Runs action with helix fetch.', async () => {
     Object.assign(process.env, {
       __OW_ACTION_NAME: '/tripod/epsagon-testing@1.0.2',


### PR DESCRIPTION
fixes #114

adds memory and container concurrency stats to epsagon:

![image](https://user-images.githubusercontent.com/917628/91004935-75e49000-e610-11ea-858f-f850d824c96b.png)

and to logging:

```
$ wsk activation logs eaa1969e407d4421a1969e407d04215e
2020-08-24T02:49:55.740Z       stderr: [INFO] instrumenting epsagon.
2020-08-24T02:49:55.745Z       stderr: [INFO] action-status { status: { mem_beg: 72261632 }, container: { age: 4, uuid: 'e252becdd581f782c9e4a53e25f267a8', numInvocations: 1, concurrency: 1 } }
2020-08-24T02:49:55.745Z       stderr: [INFO] requesting "test" action".
2020-08-24T02:49:55.862Z       stderr: [INFO] got response from 24ae15d4cb624cb5ae15d4cb62acb5c7
2020-08-24T02:49:55.862Z       stderr: [INFO] requesting "readme.md"
2020-08-24T02:49:56.158Z       stderr: [INFO] got response ![helix bridge](robynne-292082-unsplash.jpg)

# Pr...
2020-08-24T02:49:56.159Z       stderr: [INFO] action-status { status: { mem_beg: 72261632, mem_end: 73703424 } }
```
