### PR TITLE
feat(status): better container instrumentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-epsagon",
-  "version": "1.3.13",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/action-status.test.js
+++ b/test/action-status.test.js
@@ -81,15 +81,15 @@ describe('Action Status Tests', () => {
     assert.equal(result, 'ok');
 
     const args1 = eventStub.getCall(0).args[1];
-    assert.ok(args1.mem_beg);
     assert.ok(args1.container.uuid);
-    assert.ok(args1.container.age);
-    assert.equal(args1.container.concurrency, 1);
+    assert.ok(args1.container.begin.mem);
+    assert.ok(args1.container.begin.age);
+    assert.equal(args1.container.begin.concurrency, 1);
     assert.equal(args1.container.numInvocations, 1);
 
     const args2 = eventStub.getCall(1).args[1];
-    assert.ok(args2.mem_end);
-    assert.equal(args2.mem_delta, args2.mem_end - args1.mem_beg);
+    assert.ok(args2.container.end.mem);
+    assert.equal(args2.container.delta.mem, args2.container.end.mem - args2.container.begin.mem);
 
     // run again
     const result2 = await wrap(simpleAction).with(epsagon)({
@@ -98,10 +98,10 @@ describe('Action Status Tests', () => {
     });
     assert.equal(result2, 'ok');
     const args3 = eventStub.getCall(2).args[1];
-    assert.ok(args3.mem_beg);
+    assert.ok(args1.container.begin.mem);
     assert.equal(args3.container.uuid, args1.container.uuid);
-    assert.ok(args3.container.age);
-    assert.equal(args3.container.concurrency, 1);
+    assert.ok(args3.container.begin.age);
+    assert.equal(args3.container.begin.concurrency, 1);
     assert.equal(args3.container.numInvocations, 2);
   });
 


### PR DESCRIPTION
The current metadata is inconsistent. for example the `container.uuid` is not logged in the end status, which makes it impossible to correlate the data.

change container instrumentation to be more consistent:

```
action-status-begin {"container":{"uuid":"295251ae065a55bd01c08708f475e458","numInvocations":1,"begin":{"mem":97116160,"age":266,"concurrency":1}}}
action-status-end {"container":{"uuid":"295251ae065a55bd01c08708f475e458","numInvocations":1,"begin":{"mem":97116160,"age":266,"concurrency":1},"end":{"mem":97124352,"age":267,"concurrency":1},"delta":{"mem":8192,"age":1}}}
```

and 

![image](https://user-images.githubusercontent.com/917628/91270314-68b3d680-e7b3-11ea-8769-c1b65fd94cc0.png)
